### PR TITLE
Updated interface to listen for hopglass-server

### DIFF
--- a/hopglass-server/config.json
+++ b/hopglass-server/config.json
@@ -24,7 +24,7 @@
       }
     ],
     "ifaces": [
-      "bat0"
+      "br-fffl"
     ],
     "storage": {
       "interval": 300,


### PR DESCRIPTION
Hopglass has to listen on the bridge, when a bridge is used, even though batctl still only works on the bat0 interface.